### PR TITLE
Team memberships and stories

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -15,13 +15,14 @@ class OauthsController < ApplicationController
   private
 
   def find_or_create_user(resp)
+    team = Team.find_by!(slack_id: resp.team.id)
     user = User.create_with(
       name: resp.user.name,
       email: resp.user.email,
       slack_id: resp.user.id
     ).find_or_initialize_by(email: resp.user.email, slack_id: resp.user.id)
 
-    if user.save
+    if user.save && team.team_memberships.find_or_create_by(user: user)
       session[:user_id] = user.id
       redirect_to me_dashboard_path, flash: { success: 'Signed in successfully' }
     else

--- a/app/controllers/team/base_controller.rb
+++ b/app/controllers/team/base_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+class Team::BaseController < ApplicationController
+  before_action :authenticate_user!
+
+  def current_team
+    @current_team ||= current_user.teams.find(params[:team_id])
+  end
+end

--- a/app/controllers/team/stories_controller.rb
+++ b/app/controllers/team/stories_controller.rb
@@ -1,0 +1,5 @@
+class Team::StoriesController < Team::BaseController
+  def index
+    @stories = current_team.stories
+  end
+end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 class Team < ActiveRecord::Base
   has_many :stories, inverse_of: :team
+  has_many :team_memberships
+  has_many :users, through: :team_memberships
 
   validates :slack_id, presence: true, uniqueness: { scope: :incoming_webhook_channel }
   validates :name, presence: true

--- a/app/models/team_membership.rb
+++ b/app/models/team_membership.rb
@@ -1,0 +1,10 @@
+class TeamMembership < ActiveRecord::Base
+
+  belongs_to :user
+  belongs_to :team
+
+  validates :user, presence: true
+  validates :team, presence: true
+  validates :user_id, uniqueness: { scoped: :team_id }
+
+end

--- a/app/models/team_membership.rb
+++ b/app/models/team_membership.rb
@@ -1,10 +1,9 @@
+# frozen_string_literal: true
 class TeamMembership < ActiveRecord::Base
-
   belongs_to :user
   belongs_to :team
 
   validates :user, presence: true
   validates :team, presence: true
   validates :user_id, uniqueness: { scoped: :team_id }
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,7 @@ class User < ActiveRecord::Base
   validates :email, presence: true, uniqueness: { case_sensitive: false }
   validates :name, presence: true
   validates :slack_id, presence: true, uniqueness: { case_sensitive: false }
+
+  has_many :team_memberships
+  has_many :teams, through: :team_memberships
 end

--- a/app/views/me/dashboards/show.slim
+++ b/app/views/me/dashboards/show.slim
@@ -6,3 +6,15 @@
       hr
 
       p Hi, #{current_user.name}
+
+      .table-responsive
+        table.table.table-striped
+          thead
+            tr
+              th Team Name
+              th Team ID
+          tbody
+            - current_user.teams.each do |team|
+              tr
+                td = team.name
+                td = team.slack_id

--- a/app/views/me/dashboards/show.slim
+++ b/app/views/me/dashboards/show.slim
@@ -13,8 +13,10 @@
             tr
               th Team Name
               th Team ID
+              th
           tbody
             - current_user.teams.each do |team|
               tr
                 td = team.name
                 td = team.slack_id
+                td = link_to 'Stories', team_stories_path(team_id: team.id), class: 'btn btn-primary'

--- a/app/views/team/stories/index.slim
+++ b/app/views/team/stories/index.slim
@@ -1,0 +1,20 @@
+.container
+  .row
+    .col-xs-12
+      h1 Stories
+
+      hr
+
+      .table-responsive
+        table.table.table-striped
+          thead
+            tr
+              th #
+              th Story Title
+              th Created At
+          tbody
+            - @stories.each do |story|
+              tr
+                td = story.id
+                td = story.title
+                td = story.created_at

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,10 @@ Rails.application.routes.draw do
     resource :dashboard, only: [:show]
   end
 
+  namespace :team do
+    resources :stories, only: [:index]
+  end
+
   root 'pages#landing'
 
 end

--- a/db/migrate/20170226041443_create_team_memberships.rb
+++ b/db/migrate/20170226041443_create_team_memberships.rb
@@ -1,0 +1,12 @@
+class CreateTeamMemberships < ActiveRecord::Migration
+  def change
+    create_table :team_memberships do |t|
+      t.references :user, index: true, foreign_key: true
+      t.references :team, index: true, foreign_key: true
+
+      t.timestamps null: false
+    end
+
+    add_index :team_memberships, [:user_id, :team_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170219053726) do
+ActiveRecord::Schema.define(version: 20170226041443) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,17 @@ ActiveRecord::Schema.define(version: 20170219053726) do
   end
 
   add_index "stories", ["team_id"], name: "index_stories_on_team_id", using: :btree
+
+  create_table "team_memberships", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "team_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "team_memberships", ["team_id"], name: "index_team_memberships_on_team_id", using: :btree
+  add_index "team_memberships", ["user_id", "team_id"], name: "index_team_memberships_on_user_id_and_team_id", unique: true, using: :btree
+  add_index "team_memberships", ["user_id"], name: "index_team_memberships_on_user_id", using: :btree
 
   create_table "teams", force: :cascade do |t|
     t.string   "slack_id",                                 null: false
@@ -69,4 +80,6 @@ ActiveRecord::Schema.define(version: 20170219053726) do
 
   add_foreign_key "estimates", "stories"
   add_foreign_key "stories", "teams"
+  add_foreign_key "team_memberships", "teams"
+  add_foreign_key "team_memberships", "users"
 end

--- a/spec/controllers/oauths_controller_spec.rb
+++ b/spec/controllers/oauths_controller_spec.rb
@@ -93,12 +93,16 @@ RSpec.describe OauthsController, type: :controller do
     context 'when sign in with slack' do
 
       let(:user) { double('user') }
+      let(:slack_team) { double('slack_team') }
+      let(:team) { create(:team) }
 
       before do
         allow(resp).to receive(:user) { user }
         allow(user).to receive(:name) { 'name' }
         allow(user).to receive(:email) { 'email' }
-        allow(user).to receive(:id) { 'id' }
+        allow(user).to receive(:id) { 'user id' }
+        allow(resp).to receive(:team) { slack_team }
+        allow(slack_team).to receive(:id) { team.slack_id }
       end
 
       context 'when success' do

--- a/spec/controllers/team/stories_controller_spec.rb
+++ b/spec/controllers/team/stories_controller_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Team::StoriesController, type: :controller do
+
+  context 'when not logged in' do
+
+    it { expect(get(:index)).to redirect_to(root_path) }
+
+  end
+
+  context 'when logged in' do
+
+    let(:user) { create(:user) }
+    let(:team) { create(:team) }
+    let!(:team_membership) { create(:team_membership, user: user, team: team) }
+
+    before { session[:user_id] = user.id }
+
+    describe 'GET #index' do
+
+      before { get :index, team_id: team.id }
+
+      it { expect(response).to have_http_status(:success) }
+      it { expect(response).to render_template(:index) }
+
+    end
+
+  end
+
+end

--- a/spec/factories/team_memberships.rb
+++ b/spec/factories/team_memberships.rb
@@ -1,0 +1,11 @@
+FactoryGirl.define do
+  factory :team_membership do
+    association :user, factory: :user, strategy: :build
+    association :team, factory: :team, strategy: :build
+
+    trait :invalid do
+      user nil
+      team nil
+    end
+  end
+end

--- a/spec/models/team_membership_spec.rb
+++ b/spec/models/team_membership_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe TeamMembership, type: :model do
+
+  subject { build(:team_membership) }
+
+  it { is_expected.to belong_to(:user) }
+  it { is_expected.to belong_to(:team) }
+
+  it { is_expected.to validate_presence(:user) }
+  it { is_expected.to validate_presence(:team) }
+  it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(:team_id) }
+
+end


### PR DESCRIPTION
## What

Store a user's team memberships locally

## Why

To associate a user with local entities, such as `stories`, etc.